### PR TITLE
Build: create the build directory if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
         "node": ">= 0.10.0"
     },
     "scripts": {
-        "test-firefox": "TEST_SERVER_PORT=9090 BROWSER_NAME='firefox' ./run-tests.sh",
+         "test-firefox": "TEST_SERVER_PORT=9090 BROWSER_NAME='firefox' ./run-tests.sh",
         "test-chrome": "TEST_SERVER_PORT=9090 BROWSER_NAME='chrome' ./run-tests.sh",
         "test": "npm run test-chrome",
         "postinstall": "bower install",
+        "prebuild": "mkdir build",
         "build": "browserify src/scribe-plugin-content-cleaner --standalone scribe-plugin-content-cleaner -t babelify > ./build/scribe-plugin-content-cleaner.js",
         "build-prod": "npm run build && uglifyjs ./build/scribe-plugin-content-cleaner.js --source-map ./build/scribe-plugin-content-cleaner.min.js.map > ./build/scribe-plugin-content-cleaner.min.js"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "node": ">= 0.10.0"
     },
     "scripts": {
-         "test-firefox": "TEST_SERVER_PORT=9090 BROWSER_NAME='firefox' ./run-tests.sh",
+        "test-firefox": "TEST_SERVER_PORT=9090 BROWSER_NAME='firefox' ./run-tests.sh",
         "test-chrome": "TEST_SERVER_PORT=9090 BROWSER_NAME='chrome' ./run-tests.sh",
         "test": "npm run test-chrome",
         "postinstall": "bower install",


### PR DESCRIPTION
Addresses #7. If the build directory didn't exist the build would fail.

This adds a prebuild step to make sure the directory exists prior to the build
